### PR TITLE
Fix leanote-push fail

### DIFF
--- a/leanote.el
+++ b/leanote.el
@@ -643,7 +643,7 @@
                              )))
             (if (> (length abstruct) 0)
                 (setq result abstruct)
-              (set result title)))))))
+              (setq result title)))))))
     (s-trim result)))
 
 ;;;###autoload


### PR DESCRIPTION
In `leanote-extra-abstract', used a wrong set function when setting result to title.